### PR TITLE
Create bulkaccountcreate.sh

### DIFF
--- a/bulkaccountcreate.sh
+++ b/bulkaccountcreate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $HOME/prysm
+for i in {1..100} #change 100 to your desired number of accounts
+do
+	bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain --password=changeme >> $HOME/beacon-chain/rawtxndata.txt
+done


### PR DESCRIPTION
This script will create however many validator keys you want, and export the raw transaction data to a txt file so it is easier to copy paste in to the prysm deposit website or metamask.